### PR TITLE
Refactor runtime and process manager internals

### DIFF
--- a/examples/dynamic_add.rs
+++ b/examples/dynamic_add.rs
@@ -11,8 +11,6 @@
 //! ```bash
 //! cargo run --example dynamic_add
 //! ```
-mod simple;
-
 use processmanager::*;
 use std::{sync::Arc, time::Duration};
 use tokio::time::{interval, sleep};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod builtin;
 ///                         },
 ///                         ProcessOperation::Control(RuntimeControlMessage::Reload) => println!("trigger relead"),
 ///                         ProcessOperation::Control(RuntimeControlMessage::Custom(_)) => println!("trigger custom action"),
+///                         ProcessOperation::Control(_) => unimplemented!(),
 ///                     }
 ///                 }
 ///

--- a/src/process_manager.rs
+++ b/src/process_manager.rs
@@ -435,7 +435,6 @@ impl ProcessControlHandler for Handle {
 ///
 /// Accounting with [`Inner::active`] is done **before** the task is actually
 /// spawned so the supervisor has an accurate count even if the spawn fails.
-
 fn spawn_child(id: usize, proc: Arc<dyn Runnable>, inner: Arc<Inner>) -> JoinHandle<()> {
     // increment *before* spawning the task – guarantees the counter is in sync
     inner.active.fetch_add(1, Ordering::SeqCst);

--- a/src/process_manager.rs
+++ b/src/process_manager.rs
@@ -1,4 +1,4 @@
-//! Dynamic supervisor for asynchronous `Runnable`s.
+//! Dynamic supervisor for asynchronous [`Runnable`] implementations.
 //
 //! A `ProcessManager` can
 //!
@@ -90,8 +90,14 @@ pub struct ProcessManager {
     id: usize,
     pre_start: Vec<Arc<dyn Runnable>>,
     inner: Arc<Inner>,
-    /// Optional human-readable name overriding the default `process-manager-<id>`.
+    /// Optional human-readable name overriding the default
+    /// `"process-manager-<id>"`.
+    ///
+    /// If `None`, [`ProcessManager::process_name`] falls back to the automatic
+    /// naming scheme.
     pub(crate) custom_name: Option<Cow<'static, str>>,
+    /// When `true`, children that finish *successfully* are removed from the
+    /// internal lists so that long-running supervisors do not leak memory.
     pub(crate) auto_cleanup: bool,
 }
 
@@ -100,7 +106,15 @@ pub struct ProcessManager {
 /* ========================================================================== */
 
 impl ProcessManager {
-    /// New manager with auto-cleanup of finished children enabled.
+    /// Creates a fresh supervisor.
+    ///
+    /// * A unique *process-manager id* is assigned automatically.
+    /// * [`auto_cleanup`](ProcessManager::auto_cleanup) is **enabled** by
+    ///   default so that finished children are removed from the internal
+    ///   bookkeeping lists.
+    ///
+    /// The manager may be configured further with [`insert`] **before** it is
+    /// started or with [`add`] **after** it is running.
     pub fn new() -> Self {
         let id = PID.fetch_add(1, Ordering::SeqCst);
 
@@ -127,9 +141,10 @@ impl ProcessManager {
         }
     }
 
-    /// Register a child **before** the supervisor is started.
+    /// Registers a child **before** the supervisor itself is started.
     ///
-    /// Panics when called after [`process_start`](Runnable::process_start).
+    /// # Panics
+    /// Panics if the manager is already running.  Use [`add`] in that case.
     pub fn insert(&mut self, process: impl Runnable) {
         assert!(
             !self.inner.running.load(Ordering::SeqCst),
@@ -139,8 +154,10 @@ impl ProcessManager {
             .push(Arc::from(Box::new(process) as Box<dyn Runnable>));
     }
 
-    /// Add a child *while* the manager is already running. The child is spawned
-    /// immediately.  Before start-up this behaves the same as [`crate::ProcessManager::insert`].
+    /// Adds a child **while the manager is already running**.
+    ///
+    /// The new `Runnable` is spawned immediately in its own Tokio task.
+    /// Calling this method **before** start-up is equivalent to [`insert`].
     pub fn add(&self, process: impl Runnable) {
         let proc: Arc<dyn Runnable> = Arc::from(Box::new(process) as Box<dyn Runnable>);
 
@@ -291,6 +308,11 @@ impl Runnable for ProcessManager {
         })
     }
 
+    /// Returns the supervisor’s public name.
+    ///
+    /// If [`custom_name`](ProcessManager::custom_name) is `Some`, that value is
+    /// returned verbatim; otherwise the default pattern
+    /// `"process-manager-<id>"` is used.
     fn process_name(&self) -> Cow<'static, str> {
         if let Some(ref name) = self.custom_name {
             name.clone()
@@ -299,6 +321,10 @@ impl Runnable for ProcessManager {
         }
     }
 
+    /// Returns a handle that can control *all* currently running children of
+    /// this manager.
+    ///
+    /// The handle can be cloned freely and used from any async context.
     fn process_handle(&self) -> Arc<dyn ProcessControlHandler> {
         Arc::new(Handle {
             inner: Arc::clone(&self.inner),
@@ -321,6 +347,8 @@ struct Handle {
 }
 
 impl ProcessControlHandler for Handle {
+    /// Broadcasts [`ProcessControlHandler::shutdown`] to every currently active
+    /// child and waits for them to complete.
     fn shutdown(&self) -> CtrlFuture<'_> {
         let inner = Arc::clone(&self.inner);
         Box::pin(async move {
@@ -381,6 +409,9 @@ impl ProcessControlHandler for Handle {
         })
     }
 
+    /// Broadcasts [`ProcessControlHandler::reload`] to every active child.
+    /// The reload operations are executed in parallel and awaited before the
+    /// future completes.
     fn reload(&self) -> CtrlFuture<'_> {
         let inner = Arc::clone(&self.inner);
         Box::pin(async move {
@@ -399,6 +430,11 @@ impl ProcessControlHandler for Handle {
 /* ========================================================================== */
 /*  Helper – spawn a single child                                             */
 /* ========================================================================== */
+/// Spawns one child task, converts panics into `RuntimeError`s and notifies the
+/// supervisor through the *completion channel*.
+///
+/// Accounting with [`Inner::active`] is done **before** the task is actually
+/// spawned so the supervisor has an accurate count even if the spawn fails.
 
 fn spawn_child(id: usize, proc: Arc<dyn Runnable>, inner: Arc<Inner>) -> JoinHandle<()> {
     // increment *before* spawning the task – guarantees the counter is in sync

--- a/src/runtime_guard.rs
+++ b/src/runtime_guard.rs
@@ -1,3 +1,43 @@
+//! Central runtime control hub.
+//!
+//! `RuntimeGuard` owns two *async* channels: a **global control** channel that
+//! forwards messages from any number of [`RuntimeHandle`]s and the
+//! **ticker channel** consumed by exactly one [`RuntimeTicker`].
+//!
+//! The guard exposes three high-level operations:
+//!
+//! 1. [`runtime_ticker`](RuntimeGuard::runtime_ticker) – creates the sole ticker
+//!    and connects it to the control fan-out.
+//! 2. [`handle`](RuntimeGuard::handle) – returns a cheap, clonable
+//!    [`ProcessControlHandler`] that broadcasts control messages.
+//! 3. [`is_running`](RuntimeGuard::is_running) /
+//!    [`block_until_shutdown`](RuntimeGuard::block_until_shutdown) – helpers
+//!    for observing runtime state in tests and demos.
+//!
+//! Dropping the ticker closes the channel which in turn lets [`is_running`]
+//! report `false`.  Constructing a second ticker is prohibited and will panic.
+//!
+//! Internally the guard spawns a “fan-out” task that waits for control messages
+//! and forwards them to the ticker once it exists.
+//!
+//! # Concurrency & safety
+//!
+//! All interior mutability is protected by `tokio::sync::Mutex`; therefore
+//! `RuntimeGuard` is `Send + Sync`.
+//!
+//! ---
+//!
+//! ```no_run
+//! # use processmanager::*;
+//! # async fn demo() {
+//! let guard  = RuntimeGuard::new();
+//! let ticker = guard.runtime_ticker().await;
+//! let handle = guard.handle();
+//!
+//! handle.reload().await;   // broadcast control instruction
+//! /* ... */
+//! # }
+//! ```
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -21,6 +61,10 @@ unsafe impl Send for RuntimeGuard {}
 unsafe impl Sync for RuntimeGuard {}
 
 impl RuntimeGuard {
+    /// Create a fresh guard and spawn the internal *fan-out* task.
+    ///
+    /// The returned instance is ready for immediate use; you typically call
+    /// [`runtime_ticker`](Self::runtime_ticker) right after construction.
     pub fn new() -> Self {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
 
@@ -52,7 +96,11 @@ impl RuntimeGuard {
         }
     }
 
-    /// Create a ticker for the caller and connect it to the control fan-out.
+    /// Create the **single** [`RuntimeTicker`] and connect it to the fan-out.
+    ///
+    /// # Panics
+    /// Panics if a ticker has already been created – i.e. the runtime is
+    /// considered “running”.
     pub async fn runtime_ticker(&self) -> RuntimeTicker {
         assert!(
             !self.is_running().await,
@@ -65,19 +113,25 @@ impl RuntimeGuard {
         ticker
     }
 
+    /// Returns `true` while the ticker (and therefore the runtime) is alive.
     pub async fn is_running(&self) -> bool {
         let lock = self.inner.runtime_ticker_ch_sender.lock().await;
         let closed = lock.as_ref().map(|s| s.is_closed()).unwrap_or(true);
         !closed
     }
 
+    /// Obtain a clonable [`ProcessControlHandler`] that broadcasts control
+    /// messages to the ticker.
     pub fn handle(&self) -> Arc<dyn ProcessControlHandler> {
         Arc::new(RuntimeHandle::new(Arc::clone(
             &self.inner.control_ch_sender,
         )))
     }
 
-    /// Busy-wait helper for tests / demos.
+    /// **Busy-wait** helper for tests and demos.
+    ///
+    /// Polls [`is_running`](Self::is_running) once every 10 ms until it
+    /// returns `false`.
     pub async fn block_until_shutdown(&self) {
         while self.is_running().await {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/src/runtime_handle.rs
+++ b/src/runtime_handle.rs
@@ -1,9 +1,22 @@
+//! [`ProcessControlHandler`] implementation that forwards runtime‐level control
+//! messages (`Shutdown`, `Reload`, …) to a shared `tokio::mpsc::Sender`.
+//!
+//! Cloning a `RuntimeHandle` is cheap – all clones share the same underlying
+//! channel.  The async [`shutdown`](ProcessControlHandler::shutdown) and
+//! [`reload`](ProcessControlHandler::reload) methods enqueue the requested
+//! operation and return immediately without waiting for it to be executed.
+//
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
 use crate::{CtrlFuture, ProcessControlHandler, RuntimeControlMessage};
 
+/// Handle produced by [`RuntimeGuard::handle`](crate::RuntimeGuard::handle).
+///
+/// Acts as a concrete [`ProcessControlHandler`]: every instruction is simply
+/// forwarded to the runtime’s central control channel.  The handle can be
+/// cloned and sent across tasks at will.
 #[derive(Debug, Clone)]
 pub struct RuntimeHandle {
     control_ch: Arc<Mutex<tokio::sync::mpsc::Sender<RuntimeControlMessage>>>,

--- a/src/runtime_process.rs
+++ b/src/runtime_process.rs
@@ -1,3 +1,12 @@
+/// Runtime-level traits and helper types.
+///
+/// This module defines:
+/// • [`Runnable`] – abstraction for long-running async components supervised by
+///   a `ProcessManager`.
+/// • [`ProcessControlHandler`] – fire-and-forget interface for broadcasting
+///   control messages.
+/// • [`RuntimeControlMessage`] – set of built-in control messages understood by
+///   the runtime helpers (`RuntimeGuard`, `RuntimeTicker`, …).
 use super::RuntimeError;
 use std::borrow::Cow;
 use std::future::Future;
@@ -7,7 +16,14 @@ use std::sync::Arc;
 /// Boxed future returned by [`Runnable::process_start`].
 pub type ProcFuture<'a> = Pin<Box<dyn Future<Output = Result<(), RuntimeError>> + Send + 'a>>;
 
-/// A long-running asynchronous component managed by the `ProcessManager`.
+/// Trait implemented by every long-running asynchronous component that should
+/// be supervised by a [`ProcessManager`].
+///
+/// The trait is **object-safe** and requires `Send + Sync + 'static`, allowing
+/// implementors to be moved across tasks and shared between threads.
+///
+/// The lifetime parameter on [`process_start`](Runnable::process_start) lets an
+/// implementor return a future that borrows from `self` if desired.
 pub trait Runnable
 where
     Self: Send + Sync + 'static,
@@ -28,7 +44,11 @@ where
 /// Boxed future returned by [`ProcessControlHandler`] control methods.
 pub type CtrlFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
-/// Handle that allows external code to control a running [`Runnable`].
+/// Minimal handle that external code can use to *control* a running
+/// [`Runnable`].
+///
+/// All methods are **fire-and-forget**: they enqueue the requested control
+/// instruction and return once the message has been sent.
 pub trait ProcessControlHandler: Send + Sync {
     fn shutdown(&self) -> CtrlFuture<'_>;
     fn reload(&self) -> CtrlFuture<'_>;
@@ -39,15 +59,28 @@ pub enum ProcessOperation<T> {
     Control(RuntimeControlMessage),
 }
 
+/// Built-in control messages understood by runtime helpers such as
+/// [`RuntimeTicker`] and [`RuntimeGuard`].
+/// Built-in control messages understood by runtime helpers such as
+/// [`RuntimeGuard`](crate::RuntimeGuard) and [`RuntimeTicker`](crate::RuntimeTicker).
+///
+/// The enum is marked `#[non_exhaustive]`, requiring downstream crates to add a
+/// wildcard arm (`_`) when pattern-matching so that new variants introduced in
+/// future releases do not break compilation.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum RuntimeControlMessage {
+    /// Trigger a *hot reload*.
     Reload,
+    /// Request a *graceful shutdown*.
     Shutdown,
-    /// User-defined messages for future extensibility.
+    /// User-defined message for custom extensions.
     Custom(Box<dyn std::any::Any + Send + Sync>),
 }
 
 impl Clone for RuntimeControlMessage {
+    /// Manual implementation is required because the enum is
+    /// `#[non_exhaustive]`; remember to update this when adding new variants.
     fn clone(&self) -> Self {
         match self {
             RuntimeControlMessage::Reload => RuntimeControlMessage::Reload,

--- a/src/runtime_ticker.rs
+++ b/src/runtime_ticker.rs
@@ -1,3 +1,14 @@
+//! Cooperative work / control multiplexer.
+//!
+//! A `RuntimeTicker` receives **control messages** from the runtime and
+//! concurrently drives a caller-supplied *work future*. Call
+//! [`tick`](Self::tick) with the future that represents *one unit of user
+//! work*; the method races it against incoming [`RuntimeControlMessage`]s and
+//! returns a [`ProcessOperation`] that tells the caller what happened first.
+//!
+//! The ticker is created internally by [`RuntimeGuard::runtime_ticker`]. Only
+//! one ticker may exist at any time.
+use std::future::Future;
 use std::sync::Arc;
 
 use tokio::{select, sync::Mutex};
@@ -22,8 +33,12 @@ impl RuntimeTicker {
         )
     }
 
-    /// Await `fut` and the control channel concurrently, returning whichever
-    /// completes first.
+    /// Race `fut` against the next control message and return the winner.
+    ///
+    /// Only one mutex lock is taken per call to inspect the control channel.
+    /// The returned [`ProcessOperation`] describes what completed first:
+    /// * `ProcessOperation::Next(res)` – the work future finished and yielded `res`.
+    /// * `ProcessOperation::Control(msg)` – a control instruction (`Reload`, `Shutdown`, …) was received.
     pub async fn tick<O, Fut>(&self, fut: Fut) -> ProcessOperation<O>
     where
         Fut: Future<Output = O>,


### PR DESCRIPTION
- Improve documentation for `IdleProcess` and `SignalReceiver` 
- Add auto cleanup of finished children in `ProcessManager`
- Clarify `ProcessManagerBuilder` docs and fix typo in field name 
- Expand docs for `RuntimeGuard`, `RuntimeHandle` and core traits 
- Enhance tracing of signal reception in `SignalReceiver` 
- Implement `RuntimeControlMessage` as non-exhaustive enum 
- Minor code style and comment refinements throughout